### PR TITLE
Clean build

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -19,3 +19,6 @@ build_flags =
 	-DCORE_DEBUG_LEVEL=4
 	-DBOARD_HAS_PSRAM
 	-mfix-esp32-psram-cache-issue
+lib_deps =
+    m5stack/M5EPD
+	bblanchon/ArduinoJson

--- a/src/global_setting.cpp
+++ b/src/global_setting.cpp
@@ -1,5 +1,5 @@
 #include "global_setting.h"
-#include "ImageResource.h"
+#include "./resources/ImageResource.h"
 #include "esp32-hal-log.h"
 #include <WiFi.h>
 


### PR DESCRIPTION
Wasn't able to build from the cloned repo due to missing dependencies M5EPD and ArduinoJson. Additionally I also fixed the relative path to ImageResource.h.

After that it works like a charm. Nicely done!